### PR TITLE
Save All icon

### DIFF
--- a/src/itaxotools/common/resources/icons/svg/save_all.svg
+++ b/src/itaxotools/common/resources/icons/svg/save_all.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="32" height="32" version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <g stroke="#000" stroke-linejoin="bevel" stroke-width="2">
+  <path d="m6 2h19.5c1 1 4.5 4 5.5 5v19c0 1 0 1-1 1h-24c-1 0-1 0-1-1v-23c0-1 0-1 1-1z" fill="#fff" stroke-linecap="square" style="paint-order:normal"/>
+  <path d="m25 3v5c0 1 0 1-1 1h-12c-1 0-1-1e-6 -1-1v-5" fill="none" stroke-linecap="square" style="paint-order:normal"/>
+  <path d="m3 5h19.5c1 1 4.5 4 5.5 5v19c0 1 0 1-1 1h-24c-1 0-1 0-1-1v-23c0-1 0-1 1-1z" fill="#fff" stroke-linecap="square" style="paint-order:normal"/>
+  <ellipse cx="15" cy="21" rx="5" ry="5" fill="#fff" stroke-linecap="round" style="paint-order:normal"/>
+  <path d="m22 6v5c0 1 0 1-1 1h-12c-1 0-1-1e-6 -1-1v-5" fill="none" stroke-linecap="square" style="paint-order:normal"/>
+ </g>
+</svg>


### PR DESCRIPTION
Some of iTaxoTools programs (e.g. TaxI, morphometricanalyzer, dnadiagnoser) have a 'Save All' button with the corresponding PNG icon. It would be useful to have such a icon in this package.

I edited a copy of 'save.svg' to create an SVG 'Save All' icon similar to one used in the programs mentioned above.